### PR TITLE
passsed the options required to pre-generate tiles to geojson-vt

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,11 @@ var helpers = require('./helpers.js');
 
 var geojson2mvt = function(geoJson, options) {
 
-    var tileIndex = geojsonvt(geoJson);
+    var tileIndex = geojsonvt(geoJson, {
+        maxZoom: options.zoom.max,
+        indexMaxZoom: options.zoom.max,
+        indexMaxPoints: 0
+    });
 
     // create the "root directory" to place downloaded tiles in
     try {fs.mkdirSync(options.rootDir, 0777);}


### PR DESCRIPTION
There was a bug of geojson2vt generating empty tiles after zoom 14 (geojson-vt's default zoom level for pre-generate tiles). 
According to `geojson-vt` docs, to pre-generate all tiles, 1. `indexMaxZoom` and `maxZoom`have to be set to the same value 2.`indexMaxPoints` needs to be set to `0`  ([This blog post](https://www.mapbox.com/blog/introducing-geojson-vt/) offers more context about this.) 

The change here passes these options `geojson-vt` requires.