### PR TITLE
Add Python 3 CORS Server

### DIFF
--- a/example/cors_server_py3.py
+++ b/example/cors_server_py3.py
@@ -1,0 +1,59 @@
+
+import http.server
+class CORSHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def send_head(self):
+        """Common code for GET and HEAD commands.
+        This sends the response code and MIME headers.
+        Return value is either a file object (which has to be copied
+        to the outputfile by the caller unless the command was HEAD,
+        and must be closed by the caller under all circumstances), or
+        None, in which case the caller has nothing further to do.
+        """
+        path = self.translate_path(self.path)
+        f = None
+        if os.path.isdir(path):
+            if not self.path.endswith('/'):
+                # redirect browser - doing basically what apache does
+                self.send_response(301)
+                self.send_header("Location", self.path + "/")
+                self.end_headers()
+                return None
+            for index in "index.html", "index.htm":
+                index = os.path.join(path, index)
+                if os.path.exists(index):
+                    path = index
+                    break
+            else:
+                return self.list_directory(path)
+        ctype = self.guess_type(path)
+        try:
+            # Always read in binary mode. Opening files in text mode may cause
+            # newline translations, making the actual size of the content
+            # transmitted *less* than the content-length!
+            f = open(path, 'rb')
+        except IOError:
+            self.send_error(404, "File not found")
+            return None
+        self.send_response(200)
+        self.send_header("Content-type", ctype)
+        fs = os.fstat(f.fileno())
+        self.send_header("Content-Length", str(fs[6]))
+        self.send_header("Last-Modified", self.date_time_string(fs.st_mtime))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.end_headers()
+        return f
+
+
+if __name__ == "__main__":
+    import os
+    import socketserver
+
+    PORT = 31338
+
+    Handler = CORSHTTPRequestHandler
+    #Handler = http.server.SimpleHTTPRequestHandler
+
+    httpd = socketserver.TCPServer(("", PORT), Handler)
+
+    print("serving at port", PORT)
+    httpd.serve_forever()


### PR DESCRIPTION
**cors_server.py** works with Python 2.x, but changes to `print`, `SimpleHTTPServer`, and `SocketServer` in Python 3 mean it doesn't work with Python 3. This Python 3 version of this CORS server simply updates syntax and import statements where necessary accounting for the following changes from Python 2 to Python 3:

`print` -> `print()`
`SimpleHTTPServer` -> `http.server`
`SocketServer` -> `socketserver`