### PR TITLE
Set tile spec version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "author": "",
   "dependencies": {
-    "geojson-vt": "^2.4.0",
-    "vt-pbf": "^2.1.2"
+    "geojson-vt": "^3.2.1",
+    "vt-pbf": "^3.1.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ var geojson2mvt = function(options) {
 
    }
    return Object.keys(pbfOptions).length ?
-      vtpbf.fromGeojsonVt(pbfOptions) :
+      vtpbf.fromGeojsonVt(pbfOptions, {version: 2}) :
       null;
 };
 


### PR DESCRIPTION
I was having trouble with mapbox-gl spewing out warnings about the tile source not using the latest tile spec version

```
Vector tile source "planview-986" layer "layer0" does not use vector tile spec v2 and therefore may have some rendering errors
```

I fixed this by telling `vt-pbf` which version to use.

Perhaps what version to use whould be supplied as an option and not be hard coded?